### PR TITLE
Add TypeScript Discord automation bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+DISCORD_TOKEN=your-bot-token
+EOD_CHANNEL_ID=eod-channel-id
+ATTENDANCE_CHANNEL_ID=attendance-channel-id
+USER_IDS=user-id-1,user-id-2,...,user-id-21
+EOD_REMINDER_CRON=0 17 * * *
+EOD_VERIFICATION_CRON=5 17 * * *
+ATTENDANCE_REMINDER_CRON=0 9 * * *
+ATTENDANCE_VERIFICATION_CRON=5 9 * * *

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
-# cursor-experiments
+# Discord Daily Automation Bot
+
+This project provides a simple Discord bot written in TypeScript that automates four daily workflows for a team of 21 members:
+
+1. Send a reminder message to the `#eod` channel encouraging everyone to post their end-of-day update.
+2. Verify that all 21 members have posted in the `#eod` channel within the past 24 hours.
+3. Send a 9:00 AM reminder message in the `#attendance` channel to prompt people to check in.
+4. At 9:05 AM, verify that all 21 members have posted in the `#attendance` channel within the past 24 hours.
+
+The schedules are implemented with cron expressions via [`node-cron`](https://github.com/node-cron/node-cron). Default times can be overridden through environment variables.
+
+## Prerequisites
+
+- Node.js 18+
+- A Discord bot token with access to the target guild
+- IDs for the `#eod` and `#attendance` text channels
+- A comma-separated list of the 21 user IDs that should be tracked
+
+## Configuration
+
+Create a `.env` file using `.env.example` as a template:
+
+```env
+DISCORD_TOKEN=your-bot-token
+EOD_CHANNEL_ID=eod-channel-id
+ATTENDANCE_CHANNEL_ID=attendance-channel-id
+USER_IDS=user-id-1,user-id-2,...,user-id-21
+EOD_REMINDER_CRON=0 17 * * *
+EOD_VERIFICATION_CRON=5 17 * * *
+ATTENDANCE_REMINDER_CRON=0 9 * * *
+ATTENDANCE_VERIFICATION_CRON=5 9 * * *
+CRON_TIMEZONE=America/Los_Angeles
+```
+
+Cron expressions default to 5 PM/5:05 PM for end-of-day reminders and 9 AM/9:05 AM for attendance. Adjust them as needed (for example, to account for timezone differences) and optionally specify `CRON_TIMEZONE` to force scheduling in a specific timezone. The bot requires the `Guilds`, `GuildMessages`, and `MessageContent` intents to fetch messages from the configured channels.
+
+## Installation
+
+Install dependencies and build the project:
+
+```bash
+npm install
+npm run build
+```
+
+> **Note:** If you are working in an offline or restricted network environment, dependency installation may fail. Ensure your environment can reach `registry.npmjs.org` or provide an offline mirror.
+
+## Usage
+
+1. Compile the TypeScript source:
+   ```bash
+   npm run build
+   ```
+2. Start the bot:
+   ```bash
+   npm start
+   ```
+
+During startup the bot logs in, schedules the cron jobs, and then runs each automation at its scheduled time. Verification jobs post a summary message in the relevant channel and mention any users who have not completed their update in the last 24 hours.
+
+For development, you can run the bot directly with `ts-node`:
+
+```bash
+npm run dev
+```
+
+## Project Structure
+
+- `src/index.ts`: Main bot implementation, cron scheduling, and verification logic.
+- `.env.example`: Sample environment configuration.
+- `tsconfig.json`: TypeScript compiler configuration.
+
+## License
+
+ISC

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "cursor-experiments",
+  "version": "1.0.0",
+  "description": "Discord automation app for daily reminders and attendance checks.",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts"
+  },
+  "keywords": [
+    "discord",
+    "automation",
+    "cron",
+    "typescript"
+  ],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "discord.js": "^14.15.3",
+    "dotenv": "^16.4.5",
+    "node-cron": "^3.0.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,199 @@
+import {
+  ChannelType,
+  Client,
+  GatewayIntentBits,
+  Message,
+  TextChannel
+} from 'discord.js';
+import cron from 'node-cron';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
+const EOD_CHANNEL_ID = process.env.EOD_CHANNEL_ID;
+const ATTENDANCE_CHANNEL_ID = process.env.ATTENDANCE_CHANNEL_ID;
+const USER_IDS = (process.env.USER_IDS ?? '')
+  .split(',')
+  .map((id) => id.trim())
+  .filter((id) => id.length > 0);
+const CRON_TIMEZONE = process.env.CRON_TIMEZONE;
+
+if (!DISCORD_TOKEN) {
+  throw new Error('DISCORD_TOKEN is not set in the environment.');
+}
+
+if (!EOD_CHANNEL_ID) {
+  throw new Error('EOD_CHANNEL_ID is not set in the environment.');
+}
+
+if (!ATTENDANCE_CHANNEL_ID) {
+  throw new Error('ATTENDANCE_CHANNEL_ID is not set in the environment.');
+}
+
+if (USER_IDS.length !== 21) {
+  console.warn(
+    `Expected 21 user IDs but received ${USER_IDS.length}. Please verify the USER_IDS environment variable.`
+  );
+}
+
+const client = new Client({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent
+  ]
+});
+
+client.once('ready', () => {
+  console.log(`Logged in as ${client.user?.tag ?? 'unknown user'}`);
+  scheduleJobs();
+});
+
+client.login(DISCORD_TOKEN).catch((error) => {
+  console.error('Failed to login to Discord:', error);
+  process.exit(1);
+});
+
+function scheduleJobs(): void {
+  scheduleTask(
+    process.env.EOD_REMINDER_CRON ?? '0 17 * * *',
+    () =>
+      sendReminder(
+        EOD_CHANNEL_ID,
+        'Friendly reminder: please post your end-of-day update!'
+      ),
+    'EOD reminder'
+  );
+
+  scheduleTask(
+    process.env.EOD_VERIFICATION_CRON ?? '5 17 * * *',
+    () => verifyPosts(EOD_CHANNEL_ID, 'end-of-day'),
+    'EOD verification'
+  );
+
+  scheduleTask(
+    process.env.ATTENDANCE_REMINDER_CRON ?? '0 9 * * *',
+    () =>
+      sendReminder(
+        ATTENDANCE_CHANNEL_ID,
+        'Good morning! Please remember to check in for attendance.'
+      ),
+    'Attendance reminder'
+  );
+
+  scheduleTask(
+    process.env.ATTENDANCE_VERIFICATION_CRON ?? '5 9 * * *',
+    () => verifyPosts(ATTENDANCE_CHANNEL_ID, 'attendance'),
+    'Attendance verification'
+  );
+}
+
+function scheduleTask(
+  cronExpression: string,
+  task: () => Promise<void>,
+  description: string
+): void {
+  try {
+    cron.schedule(
+      cronExpression,
+      () => {
+        task().catch((error) => {
+          console.error(`Error while running ${description} task:`, error);
+        });
+      },
+      {
+        timezone: CRON_TIMEZONE
+      }
+    );
+
+    console.log(
+      `Scheduled ${description} job with cron expression: ${cronExpression}` +
+        (CRON_TIMEZONE ? ` (timezone: ${CRON_TIMEZONE})` : '')
+    );
+  } catch (error) {
+    console.error(`Failed to schedule ${description} job (${cronExpression}):`, error);
+  }
+}
+
+async function sendReminder(channelId: string, message: string): Promise<void> {
+  const channel = await fetchTextChannel(channelId);
+  await channel.send({ content: message });
+  console.log(`Sent reminder to #${channel.name}: ${message}`);
+}
+
+async function verifyPosts(channelId: string, label: string): Promise<void> {
+  const channel = await fetchTextChannel(channelId);
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const messages = await fetchMessagesSince(channel, since);
+
+  const usersWhoPosted = new Set<string>();
+  for (const message of messages) {
+    if (USER_IDS.includes(message.author.id)) {
+      usersWhoPosted.add(message.author.id);
+    }
+  }
+
+  const missingUsers = USER_IDS.filter((id) => !usersWhoPosted.has(id));
+
+  if (missingUsers.length === 0) {
+    console.log(`All users completed their ${label} posts in #${channel.name}.`);
+  } else {
+    const mentionList = missingUsers.map((id) => `<@${id}>`).join(', ');
+    await channel.send({
+      content: `The following users still need to complete their ${label} update: ${mentionList}`
+    });
+    console.warn(
+      `Missing ${label} updates from ${missingUsers.length} users in #${channel.name}: ${missingUsers.join(', ')}`
+    );
+  }
+}
+
+async function fetchTextChannel(channelId: string): Promise<TextChannel> {
+  const channel = await client.channels.fetch(channelId);
+
+  if (!channel || channel.type !== ChannelType.GuildText) {
+    throw new Error(`Channel ${channelId} is not a text channel or could not be found.`);
+  }
+
+  return channel as TextChannel;
+}
+
+async function fetchMessagesSince(
+  channel: TextChannel,
+  since: Date
+): Promise<Message<true>[]> {
+  const collected: Message<true>[] = [];
+  let before: string | undefined;
+  let shouldContinue = true;
+
+  while (shouldContinue) {
+    const options: { limit: number; before?: string } = { limit: 100 };
+    if (before) {
+      options.before = before;
+    }
+
+    const batch = await channel.messages.fetch(options);
+
+    if (batch.size === 0) {
+      break;
+    }
+
+    for (const message of batch.values()) {
+      if (message.createdAt < since) {
+        shouldContinue = false;
+        break;
+      }
+      collected.push(message);
+    }
+
+    const lastMessage = batch.last();
+    if (!lastMessage || lastMessage.createdAt < since) {
+      break;
+    }
+
+    before = lastMessage.id;
+  }
+
+  return collected;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- implement a TypeScript Discord bot that schedules daily reminders and verification tasks for EOD and attendance channels
- add configuration, TypeScript build settings, and an environment template to support the bot
- document setup, configuration, and usage details in the README

## Testing
- npm install *(fails: 403 Forbidden to registry.npmjs.org in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e497ed2454832281a4b4848570dd0c